### PR TITLE
Fix unnecessary horizontal scrollbar on guides page & scrollbar flickering on homepage

### DIFF
--- a/index.css
+++ b/index.css
@@ -2,7 +2,7 @@
   box-sizing: border-box;
 }
 body {
-  width: 100vw;
+  width: 100%;
   /* height: 100vh; */
   margin: 0;
   font-family: 'Open Sans';
@@ -25,7 +25,7 @@ header {
   display: flex;
   top: 0;
   left: 0;
-  width: 100vw;
+  width: 100%;
   height: 50px;
   background-color: #FFF;
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.08);


### PR DESCRIPTION
When using 100vw widths, if there is a vertical scrollbar then a
horizontal scrollbar is also added because of the width consumed by the
vertical one.

Using %-based widths fixes this and also fixes the flickering on the
main page when hovering over the right-side panels.

---

Example of the flickering that's been fixed:

![flickering](https://user-images.githubusercontent.com/8850830/84058700-7d04e600-a9b1-11ea-83de-09ef8da7bfec.gif)

---

Scrollbar on guides page that has been removed:

![guides page horizontal scrollbar](https://user-images.githubusercontent.com/8850830/84058862-b3dafc00-a9b1-11ea-917a-6db56a8386f6.png)

